### PR TITLE
No anaconda plus lesson data

### DIFF
--- a/_includes/install_instructions/python.html
+++ b/_includes/install_instructions/python.html
@@ -11,10 +11,9 @@ https://jupyter-notebook.readthedocs.io/en/stable/notebook.html#browser-compatib
   <p>
     <a href="https://python.org">Python</a> is a popular language for
     research computing, and great for general-purpose programming as
-    well.  Installing all of its research packages individually can be
-    a bit difficult, so we recommend
-    <a href="https://www.anaconda.com/download/success">Anaconda</a>,
-    an all-in-one installer.
+    well. We'll be using some standard tools to first install Python
+    and then the packages required for this workshop using
+    <a href="https://pip.pypa.io/en/stable/installation/">pip</a>.
   </p>
 
   <p>
@@ -29,8 +28,8 @@ https://jupyter-notebook.readthedocs.io/en/stable/notebook.html#browser-compatib
   if you do not plan to use Jupyter Notebook environment.
   {% endcomment %}
   <p>
-    We will teach Python using the <a href="https://jupyter.org/">Jupyter Notebook</a>,
-    a programming environment that runs in a web browser (Jupyter Notebook will be installed by Anaconda). For this to work you will need a reasonably
+    We will teach Python using the <a href="https://jupyter.org/">Jupyter Lab notebooks</a>,
+    a programming environment that runs in a web browser (Jupyter Lab will be installed by pip). For this to work you will need a reasonably
     up-to-date browser. The current versions of the Chrome, Safari and
     Firefox browsers are all
     <a href="https://jupyter-notebook.readthedocs.io/en/stable/notebook.html#browser-compatibility">supported</a>
@@ -48,9 +47,23 @@ https://jupyter-notebook.readthedocs.io/en/stable/notebook.html#browser-compatib
     <div class="tab-content">
       <article role="tabpanel" class="tab-pane active" id="python-windows">
         <ol>
-          <li>Open <a href="https://www.anaconda.com/download/success">https://www.anaconda.com/download/success</a> with your web browser.</li>
-          <li>Download the Anaconda for Windows installer with Python 3. (If you are not sure which version to choose, you probably want the 64-bit Graphical Installer <em>Anaconda3-...-Windows-x86_64.exe</em>)</li>
-          <li>Install Python 3 by running the Anaconda Installer, using all of the defaults for installation <em>except</em> make sure to check <strong>Add Anaconda to my PATH environment variable</strong>.</li>
+          <li>Open <a href="https://www.python.org/downloads/">https://www.python.org/downloads/</a> with your web browser.</li>
+          <li>Click on <kbd>Download Python 3.x.y</kbd> under "Download the latest version for Windows" near the top.</li>
+	  <li>Click on the downloaded installer and run it.</li>
+          <li>You'll see a popup window from the installer. Check the "Add python.exe to PATH" box near the bottom
+	    and then click <kbd>Install Now</kbd>.</li>
+	  <li>To confirm that it's installed, open git-bash (installed per the instructions above)
+	    and type <kbd>python --version</kbd>. This should print something like:"Python 3.12.5".</li>
+          <li>Next we'll install Jupyter Lab and the various Python packages we'll be using.
+	    These will all be installed in a Python "Virtual Environment" (venv). Type these commands in the git-bash shell:
+            <pre>
+	     cd ~/Desktop
+	     python -m venv venv
+	     source venv/Scripts/activate
+	     pip install jupyterlab ipywidgets pandas matplotlib
+	    </pre>
+	    That last step will take a while and will print a lot of progress output showing the packages being installed.
+	  </li>
         </ol>
         <h4>Video Tutorial</h4>
         <div class="yt-wrapper2">
@@ -61,10 +74,23 @@ https://jupyter-notebook.readthedocs.io/en/stable/notebook.html#browser-compatib
       </article>
       <article role="tabpanel" class="tab-pane" id="python-macos">
         <ol>
-          <li>Open <a href="https://www.anaconda.com/download/success">https://www.anaconda.com/download/success</a> with your web browser.</li>
-          <li>Download the Anaconda Installer with Python 3 for macOS (you can either use the Graphical or the Command Line Installer).</li>
-          <li>Install Python 3 by running the Anaconda Installer using all of the defaults for installation.</li>
+          <li>Open <a href="https://www.python.org/downloads/">https://www.python.org/downloads/</a> with your web browser.</li>
+          <li>Click on <kbd>Download Python 3.x.y</kbd> under "Download the latest version for macOS" near the top.</li>
+	  <li>Click on the downloaded installer and run it, responding to the license agreement prompt, and so on.</li>
+	  <li>To confirm that it's installed, open Terminal
+	    and type <kbd>python --version</kbd>. This should print something like:"Python 3.12.5".</li>
+          <li>Next we'll install Jupyter Lab and the various Python packages we'll be using.
+	    These will all be installed in a Python "Virtual Environment" (venv). Type these commands in the git-bash shell:
+            <pre>
+	     cd ~/Desktop
+	     python -m venv venv
+	     source venv/bin/activate
+	     pip install jupyterlab ipywidgets pandas matplotlib
+	    </pre>
+	    That last step will take a while and will print a lot of progress output showing the packages being installed.
+	  </li>
         </ol>
+
         <h4>Video Tutorial</h4>
         <div class="yt-wrapper2">
         <div class="yt-wrapper">
@@ -73,39 +99,20 @@ https://jupyter-notebook.readthedocs.io/en/stable/notebook.html#browser-compatib
         </div>
       </article>
       <article role="tabpanel" class="tab-pane" id="python-linux">
+        Python is usually already installed on most Linux distributions.
         <ol>
-          <li>Open <a href="https://www.anaconda.com/download/success">https://www.anaconda.com/download/success</a> with your web browser.</li>
-          <li>Download the Anaconda Installer with Python 3 for Linux.<br>
-            (The installation requires using the shell. If you aren't
-            comfortable doing the installation yourself
-            stop here and request help at the workshop.)
-          </li>
-          <li>
-            Open a terminal window and navigate to the directory where
-            the executable is downloaded (e.g., `cd ~/Downloads`).
-          </li>
-          <li>
-            Type <pre>bash Anaconda3-</pre> and then press
-            <kbd>Tab</kbd> to autocomplete the full file name. The name of
-            file you just downloaded should appear.
-          </li>
-          <li>
-            Press <kbd>Enter</kbd>
-            (or <kbd>Return</kbd> depending on your keyboard).
-            You will follow the text-only prompts.
-            To move through the text, press <kbd>Spacebar</kbd>.
-            Type <code>yes</code> and press enter to approve the license.
-            Press <kbd>Enter</kbd> (or <kbd>Return</kbd>)
-            to approve the default location
-            for the files.
-            Type <code>yes</code> and press
-            <kbd>Enter</kbd> (or <kbd>Return</kbd>)
-            to prepend Anaconda to your <code>PATH</code>
-            (this makes the Anaconda distribution the default Python).
-          </li>
-          <li>
-            Close the terminal window.
-          </li>
+	  <li>To confirm that it's installed, open a terminal
+	    and type <kbd>python3 --version</kbd>. This should print something like:"Python 3.12.5".</li>
+          <li>Next we'll install Jupyter Lab and the various Python packages we'll be using.
+	    These will all be installed in a Python "Virtual Environment" (venv). Type these commands in the git-bash shell:
+            <pre>
+	     cd
+	     python3 -m venv venv
+	     source venv/bin/activate
+	     pip install jupyterlab ipywidgets pandas matplotlib
+	    </pre>
+	    That last step will take a while and will print a lot of progress output showing the packages being installed.
+	  </li>
         </ol>
       </article>
     </div>

--- a/_includes/install_instructions/python.html
+++ b/_includes/install_instructions/python.html
@@ -65,12 +65,12 @@ https://jupyter-notebook.readthedocs.io/en/stable/notebook.html#browser-compatib
 	    That last step will take a while and will print a lot of progress output showing the packages being installed.
 	  </li>
         </ol>
-        <h4>Video Tutorial</h4>
-        <div class="yt-wrapper2">
-        <div class="yt-wrapper">
-        <iframe type="text/html" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" src="https://www.youtube-nocookie.com/embed/xxQ0mzZ8UvA?modestbranding=1&playsinline=1&iv_load_policy=3&rel=0" class="yt-frame" allowfullscreen></iframe>
-        </div>
-        </div>
+        <!-- <h4>Video Tutorial</h4> -->
+        <!-- <div class="yt-wrapper2"> -->
+        <!-- <div class="yt-wrapper"> -->
+        <!-- <iframe type="text/html" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" src="https://www.youtube-nocookie.com/embed/xxQ0mzZ8UvA?modestbranding=1&playsinline=1&iv_load_policy=3&rel=0" class="yt-frame" allowfullscreen></iframe> -->
+        <!-- </div> -->
+        <!-- </div> -->
       </article>
       <article role="tabpanel" class="tab-pane" id="python-macos">
         <ol>
@@ -91,12 +91,12 @@ https://jupyter-notebook.readthedocs.io/en/stable/notebook.html#browser-compatib
 	  </li>
         </ol>
 
-        <h4>Video Tutorial</h4>
-        <div class="yt-wrapper2">
-        <div class="yt-wrapper">
-        <iframe type="text/html" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" src="https://www.youtube-nocookie.com/embed/TcSAln46u9U?modestbranding=1&playsinline=1&iv_load_policy=3&rel=0" class="yt-frame" allowfullscreen></iframe>
-        </div>
-        </div>
+        <!-- <h4>Video Tutorial</h4> -->
+        <!-- <div class="yt-wrapper2"> -->
+        <!-- <div class="yt-wrapper"> -->
+        <!-- <iframe type="text/html" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" src="https://www.youtube-nocookie.com/embed/TcSAln46u9U?modestbranding=1&playsinline=1&iv_load_policy=3&rel=0" class="yt-frame" allowfullscreen></iframe> -->
+        <!-- </div> -->
+        <!-- </div> -->
       </article>
       <article role="tabpanel" class="tab-pane" id="python-linux">
         Python is usually already installed on most Linux distributions.

--- a/index.md
+++ b/index.md
@@ -468,3 +468,19 @@ Please check the "Setup" page of
 <a href="{{site.incubator_lesson_site}}">the lesson homepage</a> for instructions to follow
 to obtain the software and data you will need to follow the lesson.
 {% endif %}
+{% if site.curriculum == "swc-gapminder" %}
+<div id="data">
+<h3>Data Used in the Lessons</h3>
+Make sure to download the required data for the Shell and Python lessons:
+
+<ul>
+<li><a href="https://swcarpentry.github.io/shell-novice/data/shell-lesson-data.zip">shell-lesson-data.zip</a></li>
+
+<li><a href="https://swcarpentry.github.io/python-novice-gapminder/files/python-novice-gapminder-data.zip">python-novice-gapminder-data.zip</a></li>
+</ul>
+{% endif %}
+
+{% comment %}
+I'm not sure what the correct zip file to download for the R class is...
+{% endcomment %}
+</div>


### PR DESCRIPTION
Replaces Anaconda-based Python installation with PIP-based installation to avoid Anaconda licensing issues.

Adds instructions to download the Shell and Python data.

